### PR TITLE
Fix CodeQL/Ubuntu build pipeline

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,13 +22,17 @@ jobs:
     steps:
     - name: Install dependencies
       run: sudo apt update 
-        && sudo apt install -y protobuf-c-compiler libprotobuf-c-dev libnuma-dev
+        && sudo apt install -y protobuf-c-compiler libprotobuf-c-dev
         
     - name: Install Libfabric
       run: git clone https://github.com/ofiwg/libfabric.git
         && cd ./libfabric
         && sudo ./autogen.sh
-        && ./configure --prefix=/opt/libfabric && make -j $(nproc) && sudo make install
+        && ./configure --prefix=/opt/libfabric
+            --enable-only
+            --enable-tcp=yes
+            --enable-rxm=yes
+        && make -j $(nproc) && sudo make install
         && sudo cp -r include/. /usr/include
 
     - name: Cleanup

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,11 +20,12 @@ jobs:
         language: [ 'cpp' ]
 
     steps:
-    - name: Install requirements
+    - name: Install dependencies
       run: sudo apt update 
-        && sudo apt install -y protobuf-c-compiler
-        && sudo apt install -y libprotobuf-c-dev
-        && git clone https://github.com/ofiwg/libfabric.git
+        && sudo apt install -y protobuf-c-compiler libprotobuf-c-dev libnuma-dev
+        
+    - name: Install Libfabric
+      run: git clone https://github.com/ofiwg/libfabric.git
         && cd ./libfabric
         && sudo ./autogen.sh
         && ./configure --prefix=/opt/libfabric && make -j $(nproc) && sudo make install

--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -18,14 +18,20 @@ jobs:
       fail-fast: false
   
     steps:
-    - name: Install requirements
+    - name: Install dependencies
       run: sudo apt update 
-        && sudo apt install -y protobuf-c-compiler
-        && sudo apt install -y libprotobuf-c-dev
-        && git clone https://github.com/ofiwg/libfabric.git
+        && sudo apt install -y protobuf-c-compiler libprotobuf-c-dev
+        
+    - name: Install Libfabric
+      run: git clone https://github.com/ofiwg/libfabric.git
         && cd ./libfabric
         && sudo ./autogen.sh
-        && ./configure --prefix=/opt/libfabric && make -j $(nproc) && sudo make install
+        && ./configure --prefix=/opt/libfabric
+            --enable-only
+            --enable-tcp=yes
+            --enable-rxm=yes
+        && make -j $(nproc)
+        && sudo make install
         && sudo cp -r include/. /usr/include
 
     - name: Cleanup


### PR DESCRIPTION
Libfabric main branch has a new provider, OPX, which resulted in CI build failures. As the CI runner only has TCP support, the Libfabric build step now only includes TCP and RXM providers.